### PR TITLE
Added GOTO command

### DIFF
--- a/Documentation/documentation.html
+++ b/Documentation/documentation.html
@@ -58,9 +58,7 @@
 <h1>Documentation</h1>
 <p>
 <ul class="nav nav-pills nav-stacked" class="pull-left">
-  <b>Note</b>: Not all functonality added to Puzzlescript+ is explained in the documentation, <a href="https://github.com/Auroriax/PuzzleScript/blob/master/README.md">you can get more info here</a>.<br><br>
   <li>Basic</li>
-  <li><a href="solver.html">How to use the Solver</a></li>
   <li><a href="rules101.html">Rules 101</a></li>
   <li><a href="prelude.html">Bird's-eye view of a PuzzleScript file</a></li>
   <li>Intermediate</li>
@@ -73,6 +71,11 @@
   <li>Advanced</li>
   <li><a href="executionorder.html">Rule Execution Order</a></li>
   <li><a href="rigidbodies.html">Extended Rigid Bodies</a></li>
+  <li>Puzzlescript+ Features</li>
+  <li><a href="solver.html">How to use the Solver</a></li>
+  <li><a href="rules.html#commands">The Goto command in rules</a></li>
+  <li><a href="levels.html#section-and-goto">Section definitions and Goto commands between levels</a></li>
+  <b>Note</b>: Not all functonality added to Puzzlescript+ is explained in the documentation, <a href="https://github.com/Auroriax/PuzzleScript/blob/master/README.md">you can get more info here</a>.<br><br>
   <li>Miscellanea</li>
   <li><a href="gifs.html">Making GIFs</a></li>
   <li><a href="permanent_urls.html">Updateable PuzzleScript.net URLs</a></li>

--- a/Documentation/levels.html
+++ b/Documentation/levels.html
@@ -117,12 +117,46 @@ Levels are separated by blank lines, and you can also display messages if you wa
 <p>
 If you hold CTRL (or, on a Mac, CMD) and left click on the level in the text editor, it will load it in game.
 <p>
-<h3>What stuff is hard to do?</h3>
+<h3 id="section-and-goto">Section and Goto (new in PuzzleScript+)</h3>
 <p>
-Branching.  I have no support for it in terms of this level structure.  If you want a continuous open world you can set <b>zoomscreen</b>, <b>flickscreen</b>, or <b>smoothscreen</b> in the <a href="prelude.html">prelude</a>.
-<p>
-If you can think of an elegant way to implement level branching in the engine, <a href="mailto:analytic@gmail.com">let me know</a>, and I'll consider it : )
+If you want to use the level_select feature or the GOTO commands, you need to divide your game into named sections.
 
+<pre><code>MESSAGE Select your preferred difficulty setting.
+
+#########
+#...P...#
+#.E...H.#
+#########
+
+SECTION Easy Levels
+
+#########
+#.P..*O.#
+#########
+
+#########
+#.P.*.O.#
+#########
+
+GOTO The End
+
+SECTION Hard Levels
+
+#########
+#.P..*O.#
+#.......#
+#########
+
+#########
+#.P.....#
+#...* O.#
+#########
+
+SECTION The End
+
+MESSAGE Congratulations!</code></pre>
+
+You can use a GOTO command to redirect the player to any named section after the preceding level was won.
 
     </div><!-- /.container -->
 

--- a/Documentation/rules.html
+++ b/Documentation/rules.html
@@ -197,6 +197,10 @@ late [Shadow] -> []</code></pre>
       <dd>Gives the player a message.  So you can say things like "Message Hello World".  Reads everything to its right, so it has to be the rightmost argument.</dd>
       <dt>sfx0 ... sfx10</dt>
       <dd>Sound effects banks - you associate these to sounds in the <a href="sounds.html">sounds</a> section, and then you can trigger them in rules by mentioning them.</dd>
+      <dt>Goto (new in Puzzlescript+)</dt>
+      <dd>immediately switches to a different level. This does not count as a win and cannot be undone by the player. Everything to the right of the Goto command is interpreted as a <a href="levels.html#section-and-goto">section name</a>.
+      <pre><code><a href="../editor.html?demo=plus_gotolevel" target="puzzleScript_EditorWindow" class="btn btn-default pull-right" ><span class="glyphicon glyphicon-cog"> Edit</span></a>late [ Player One ] -> GOTO Section 1
+late [ Player Hub ] -> GOTO Hub</code></pre></dd>
     </dl>
 <p>
    	<h3>What stuff is hard to do?</h3>

--- a/css/midnight.css
+++ b/css/midnight.css
@@ -56,6 +56,8 @@
 .cm-s-midnight span.cm-MESSAGE {color: orange;font-style:italic;}
 .cm-s-midnight span.cm-SECTION_VERB {color: rgb(129, 255, 156);font-weight:bold;}
 .cm-s-midnight span.cm-SECTION {color: orange;font-style:italic;}
+.cm-s-midnight span.cm-GOTO_VERB {color: #AE81FF;font-weight:bold;}
+.cm-s-midnight span.cm-GOTO {color: orange;font-style:italic;}
 .cm-s-midnight span.cm-METADATA {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-METADATATEXT {color: orange;font-style:italic;}
 

--- a/demo/plus_gotolevel.txt
+++ b/demo/plus_gotolevel.txt
@@ -1,0 +1,182 @@
+title My Game
+author My Name Here
+homepage www.puzzlescript.net
+
+========
+OBJECTS
+========
+
+background .
+black  
+
+wall #
+brown darkbrown
+00010
+11111
+01000
+11111
+00010
+
+player p
+black orange white blue
+.000.
+.111.
+22222
+.333.
+.3.3.
+
+one 1 
+red 
+..0..
+..0..
+..0..
+..0..
+..0..
+
+two 2
+yellow 
+.000.
+...0.
+.000.
+.0...
+.000.
+
+tre 3
+blue 
+.000.
+...0.
+.000.
+...0.
+.000.
+
+hub x
+gray
+0...0
+.0.0.
+..0..
+.0.0.
+0...0
+
+victory ~
+gray
+..0..
+...0.
+00000
+...0.
+..0..
+
+=======
+LEGEND
+=======
+
+=======
+SOUNDS
+=======
+
+================
+COLLISIONLAYERS
+================
+
+background
+one, two, tre, hub, victory
+player, wall
+
+======
+RULES     
+======     
+
+late [player one] -> Goto SECTION 1
+late [player two] -> goto Section 2
+late [player tre] -> GOTO section 3
+late [player hub] -> goto hub
+late [player victory] -> win
+
+==============
+WINCONDITIONS
+==============
+
+=======     
+LEVELS
+=======
+message Intro
+
+#########
+#.......#
+#.......#
+#..p.~..#
+#.......#
+#.......#
+#########
+
+section Hub
+
+#########
+#.......#
+#.....1.#
+#.p...2.#
+#.....3.#
+#.......#
+#########
+
+section Section 1
+message Section 1, two levels
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..1.1..#
+#########
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..1.2..#
+#########
+
+goto Hub
+
+section Section 2
+message Section 2, three levels
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..2.1..#
+#########
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..2.2..#
+#########
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..2.3..#
+#########
+
+goto Hub
+
+section Section 3
+message Section 3, one levels
+
+#########
+#.......#
+#.x.p.~.#
+#.......#
+#########
+#..3.1..#
+#########
+
+goto Hub

--- a/editor.html
+++ b/editor.html
@@ -107,6 +107,7 @@ LEVELS
 	<option value="plus_twiddle">Realtime Metadata Twiddling</option>
 	<option value="plus_localradius">Local Radius [Jack Lance fork]</option>
 	<option value="plus_levelselect">Level Select [Dario fork]</option>
+	<option value="plus_gotolevel">Goto Level</option>
 	<option value="plus_nonogram">Nonogram (BoredMatt)</option>
 	<option value="plus_sokobanana">Sokobanana (Auroriax)</option>
 <optgroup label="Tutorial">

--- a/js/codemirror/anyword-hint.js
+++ b/js/codemirror/anyword-hint.js
@@ -66,7 +66,7 @@
         var RULE_COMMAND_WORDS = [
             "COMMAND",
             "sfx0", "sfx1", "sfx2", "sfx3", "sfx4", "sfx5", "sfx6", "sfx7", "sfx8", "sfx9", "sfx10", "cancel", "checkpoint", "restart", "win", "message", "again", "nosave", "quit",
-            "global", "zoomscreen", "flickscreen", "smoothscreen", "key_repeat_interval", "again_interval", "realtime_interval", "background_color", "text_color", "noundo", "norestart"];
+            "global", "zoomscreen", "flickscreen", "smoothscreen", "key_repeat_interval", "again_interval", "realtime_interval", "background_color", "text_color", "noundo", "norestart", "goto"];
 
         var CARDINAL_DIRECTION_WORDS = [
             "DIRECTION",
@@ -218,6 +218,7 @@
                         if (lineToCursor.trim().split(/\s+/ ).length<2) {
                             candlists.push(["MESSAGE_VERB","message"]);
                             candlists.push(["SECTION_VERB","section"]);
+                            candlists.push(["GOTO_VERB"   ,"goto"   ]);
                         }
                         break;
                     }

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -543,7 +543,7 @@ function levelsToArray(state) {
 			continue;
 		}
 		
-		if (level[0] == '\n') {
+		if (level[0] == 'message') {
 
 			var o = {
 				message: level[1],
@@ -554,6 +554,13 @@ function levelsToArray(state) {
 				logWarning('Message too long to fit on screen.', level[2]);
 			}
 
+			processedLevels.push(o);
+		} else if (level[0] == 'goto') {
+			var o = {
+				target: level[1],
+				lineNumber: level[2],
+				section: level[3]
+			};
 			processedLevels.push(o);
 		} else {
 			var o = levelFromString(state,level);
@@ -591,6 +598,54 @@ function extractSections(state) {
 	state.sections = sections;
 }
 
+function convertSectionNamesToIndices(state) {
+	var sectionMap = {};
+	var duplicateSections = {};
+	for (var s = 0; s < state.sections.length; s++) {
+		var sectionName = state.sections[s].name.toLowerCase();
+		if(sectionMap[sectionName] === undefined){
+			sectionMap[sectionName] = s;
+		}else{
+			duplicateSections[sectionName] = true;
+		}
+	}
+	
+	// GOTO commands in the RULES
+	for (var r = 0; r < state.rules.length; r++) {
+		var rule = state.rules[r];
+		for (var c = 0; c < rule.commands.length; c++) {
+			var command = rule.commands[c];
+			if (command[0] != 'goto') continue;
+			var sectionName = command[1].toLowerCase();
+			var sectionIndex = sectionMap[sectionName];
+			if (sectionIndex === undefined){
+				logError('Invalid GOTO command - There is no section named "'+command[1]+'".', rule.lineNumber);
+				sectionIndex = 0;
+			}else if (duplicateSections[sectionName] !== undefined){
+				logError('Invalid GOTO command - There are multiple sections named "'+command[1]+'".', rule.lineNumber);
+				sectionIndex = 0;
+			}
+			command[1] = sectionIndex;
+		}
+	}
+	
+	// GOTO commands in the LEVELS
+	for (var i = 0; i < state.levels.length; i++) {
+		var level = state.levels[i];
+		if (level.target === undefined) continue; // This was a level or a message, but not a goto.
+		var targetName = level.target.toLowerCase();
+		var targetIndex = sectionMap[targetName];
+		if (targetIndex === undefined){
+			logError('Invalid GOTO command - There is no section named "'+command[1]+'".', level.lineNumber);
+			targetIndex = 0;
+		}else if (duplicateSections[targetName] !== undefined){
+			logError('Invalid GOTO command - There are multiple sections named "'+command[1]+'".', level.lineNumber);
+			targetIndex = 0;
+		}
+		level.target = targetIndex;
+	}
+}
+
 var directionaggregates = {
 	'horizontal' : ['left', 'right'],
 	'vertical' : ['up', 'down'],
@@ -606,7 +661,7 @@ var simpleRelativeDirections = ['^', 'v', '<', '>'];
 var reg_directions_only = /^(\>|\<|\^|v|up|down|left|right|moving|stationary|no|randomdir|random|horizontal|vertical|orthogonal|perpendicular|parallel|action)$/i;
 //redeclaring here, i don't know why
 var commandwords = ["sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10","cancel","checkpoint","restart","win","message","again","undo",
-  "nosave","quit","zoomscreen","flickscreen","smoothscreen","again_interval","realtime_interval","key_repeat_interval",'noundo','norestart','background_color','text_color'];
+  "nosave","quit","zoomscreen","flickscreen","smoothscreen","again_interval","realtime_interval","key_repeat_interval",'noundo','norestart','background_color','text_color','goto'];
 function directionalRule(rule) {
 	for (var i=0;i<rule.lhs.length;i++) {
 		var cellRow = rule.lhs[i];
@@ -847,6 +902,15 @@ function processRuleString(rule, state, curRules)
 						}
 						commands.push([token.toLowerCase(), messageStr]);
 						i=tokens.length;
+					}else if (token.toLowerCase()==='goto') {
+						var messageIndex = findIndexAfterToken(origLine,tokens,i);
+						var messageStr = origLine.substring(messageIndex).trim();
+						if (messageStr===""){
+							messageStr=" ";
+							//needs to be nonempty or the system gets confused and thinks it's a whole level message rather than an interstitial.
+						}
+						commands.push([token.toLowerCase(), messageStr]);
+						i=tokens.length;
 					} else if (twiddleable_params.includes(token.toLowerCase())) {
 						if (!state.metadata.includes("runtime_metadata_twiddling")) {
 							logError("You can only change a flag at runtime if you have the 'runtime_metadata_twiddling' prelude flag defined!",lineNumber)
@@ -920,6 +984,10 @@ function processRuleString(rule, state, curRules)
 		} else if (cmd==='cancel') {
 			if (commands.length>1 || rhs_cells.length>0) {
 				logError('The CANCEL command can only appear by itself on the right hand side of the arrow.', lineNumber);
+			}
+		} else if (cmd==='goto') {
+			if (commands.length>1 || rhs_cells.length>0) {
+				logError('The GOTO command can only appear by itself on the right hand side of the arrow.', lineNumber);
 			}
 		}
 	}
@@ -1905,6 +1973,7 @@ function checkNoLateRulesHaveMoves(state){
 	}
 }
 
+
 function generateRigidGroupList(state) {
 	var rigidGroupIndex_to_GroupIndex=[];
 	var groupIndex_to_RigidGroupIndex=[];
@@ -2652,6 +2721,7 @@ function loadFile(str) {
 	rulesToArray(state);
 
 	removeDuplicateRules(state);
+	convertSectionNamesToIndices(state);
 
 	if (debugMode) {
 		printRules(state);

--- a/js/inputoutput.js
+++ b/js/inputoutput.js
@@ -1285,7 +1285,7 @@ function update() {
 			if(titleMode <= 1) {
 				nextLevel();
 			} else if(titleMode == 2) {
-				gotoSelectedLevel();
+				gotoLevel(titleSelection);
 			}
         }
     }

--- a/js/parser.js
+++ b/js/parser.js
@@ -185,7 +185,7 @@ var codeMirrorFn = function() {
     //var logicWords = ['all', 'no', 'on', 'some'];
     var sectionNames = ['objects', 'legend', 'sounds', 'collisionlayers', 'rules', 'winconditions', 'levels'];
     var commandwords = ["sfx0","sfx1","sfx2","sfx3","sfx4","sfx5","sfx6","sfx7","sfx8","sfx9","sfx10","cancel","checkpoint","restart","win","message","again","undo",
-      "nosave","quit","zoomscreen","flickscreen","smoothscreen","again_interval","realtime_interval","key_repeat_interval",'noundo','norestart','background_color','text_color'];
+      "nosave","quit","zoomscreen","flickscreen","smoothscreen","again_interval","realtime_interval","key_repeat_interval",'noundo','norestart','background_color','text_color','goto'];
     //var reg_commands = /\s*(sfx0|sfx1|sfx2|sfx3|Sfx4|sfx5|sfx6|sfx7|sfx8|sfx9|sfx10|cancel|checkpoint|restart|win|message|again|undo|nosave)\s*/;
     var reg_name = /[\w]+\s*/;///\w*[a-uw-zA-UW-Z0-9_]/;
     //var reg_number = /[\d]+/;
@@ -202,7 +202,7 @@ var codeMirrorFn = function() {
     var reg_sounddirectionindicators = /\s*(up|down|left|right|horizontal|vertical|orthogonal)\s*/i;
     var reg_winconditionquantifiers = /^(all|any|no|some)$/i;
     //var reg_keywords = /(checkpoint|objects|collisionlayers|legend|sounds|rules|winconditions|\.\.\.|levels|up|down|left|right|^|\||\[|\]|v|\>|\<|no|horizontal|orthogonal|vertical|any|all|no|some|moving|stationary|parallel|perpendicular|action|nosave)/;
-    var keyword_array = ['checkpoint','objects', 'collisionlayers', 'legend', 'sounds', 'rules', '...','winconditions', 'levels','|','[',']','up', 'down', 'left', 'right', 'late','rigid', '^','v','\>','\<','no','randomdir','random', 'horizontal', 'vertical','any', 'all', 'no', 'some', 'moving','stationary','parallel','perpendicular','action','nosave','message','global','zoomscreen','flickscreen','smoothscreen','noundo','norestart','background_color','text_color'];
+    var keyword_array = ['checkpoint','objects', 'collisionlayers', 'legend', 'sounds', 'rules', '...','winconditions', 'levels','|','[',']','up', 'down', 'left', 'right', 'late','rigid', '^','v','\>','\<','no','randomdir','random', 'horizontal', 'vertical','any', 'all', 'no', 'some', 'moving','stationary','parallel','perpendicular','action','nosave','message','global','zoomscreen','flickscreen','smoothscreen','noundo','norestart','background_color','text_color','goto'];
 
     var preamble_params = ['title','author','homepage','background_color','text_color','key_repeat_interval','realtime_interval','again_interval','flickscreen','zoomscreen','smoothscreen','color_palette','youtube',
       'sprite_size','level_select_unlocked_ahead','level_select_solve_symbol','custom_font', 'mouse_left','mouse_drag','mouse_right','mouse_rdrag','mouse_up','mouse_rup','local_radius','font_size'];
@@ -1104,7 +1104,7 @@ var codeMirrorFn = function() {
                                 } else if (m==='global') {
                                     return 'DIRECTION';
                                 }else if (commandwords.indexOf(m)>=0) {
-									if (m==='message' || twiddleable_params.includes(m)) {
+									if (m==='message' || m==='goto' || twiddleable_params.includes(m)) {
 										state.tokenIndex=-4;
 									}                                	
                                 	return 'COMMAND';
@@ -1168,8 +1168,8 @@ var codeMirrorFn = function() {
                         if (sol)
                         {
                             if (stream.match(/\s*message\s*/i, true)) {
-                                state.tokenIndex = 1;//1/2/3 = message/level/section
-                                var newdat = ['\n', mixedCase.slice(stream.pos).trim(), state.lineNumber, state.currentSection];
+                                state.tokenIndex = 1;//1/2/3/4 = message/level/section/goto
+                                var newdat = ['message', mixedCase.slice(stream.pos).trim(), state.lineNumber, state.currentSection];
                                 if (state.levels[state.levels.length - 1].length == 0) {
                                     state.levels.splice(state.levels.length - 1, 0, newdat);
                                 } else {
@@ -1177,9 +1177,19 @@ var codeMirrorFn = function() {
                                 }
                                 return 'MESSAGE_VERB';
                             } else if (stream.match(/\s*section\s*/i, true)) {
-                                state.tokenIndex = 3;//1/2/3 = message/level/section
+                                state.tokenIndex = 3;//1/2/3/4 = message/level/section/goto
                                 state.currentSection = mixedCase.slice(stream.pos).trim();
                                 return 'SECTION_VERB';
+                            } else if (stream.match(/\s*goto\s*/i, true)) {
+                                state.tokenIndex = 4;//1/2/3/4 = message/level/section/goto
+                                var newdat = ['goto', mixedCase.slice(stream.pos).trim(), state.lineNumber, state.currentSection];
+                                if (state.levels[state.levels.length - 1].length == 0) {
+                                    state.levels.splice(state.levels.length - 1, 0, newdat);
+                                } else {
+                                    state.levels.push(newdat);
+                                }
+                                state.currentSection = null;
+                                return 'GOTO_VERB';
                             } else {
                                 var line = stream.match(reg_notcommentstart, false)[0].trim();
                                 state.tokenIndex = 2;
@@ -1209,13 +1219,10 @@ var codeMirrorFn = function() {
                                	return 'MESSAGE';
                             } else if (state.tokenIndex == 3) {
                                 stream.skipToEnd();
-
-                                if(state.metadata.indexOf("level_select")==-1) {
-                                    logError("Can't use sections without level_select parameter in preamble", state.lineNumber);
-                                    return 'ERROR';
-                                }
-
                                 return 'SECTION';
+                            } else if (state.tokenIndex == 4) {
+                                stream.skipToEnd();
+                                return 'GOTO';
                             }
                         }
 

--- a/js/parser.js
+++ b/js/parser.js
@@ -1188,7 +1188,6 @@ var codeMirrorFn = function() {
                                 } else {
                                     state.levels.push(newdat);
                                 }
-                                state.currentSection = null;
                                 return 'GOTO_VERB';
                             } else {
                                 var line = stream.match(reg_notcommentstart, false)[0].trim();


### PR DESCRIPTION
Hi.
I added a goto command to the rules section and to the levels section. There is a small example (demo/plus_gotolevel.txt), which demonstrates both of these.
Note that leaving a level via a goto rule is not counted as a win on the level select screen. If there's demand, we could implement a `win goto <section name>` command combination.